### PR TITLE
Drop PWP::Encoding dependency

### DIFF
--- a/weaver.ini
+++ b/weaver.ini
@@ -1,3 +1,1 @@
 [@Default]
-
-[-Encoding]


### PR DESCRIPTION
Actually, #1 is a bit wrong, since `@Default` bundle includes `SingleEncoding`, so you are fine just like that.
