### PR TITLE
Recursively fetch responses when there's more than one page.

### DIFF
--- a/lib/WebService/DigitalOcean.pm
+++ b/lib/WebService/DigitalOcean.pm
@@ -1,7 +1,7 @@
 package WebService::DigitalOcean;
 # ABSTRACT: Access the DigitalOcean RESTful API (v2)
 use Moo;
-use Types::Standard qw/Str/;
+use Types::Standard qw/Str Bool/;
 use LWP::UserAgent;
 use JSON ();
 use DateTime;
@@ -30,6 +30,12 @@ has token => (
     is       => 'ro',
     isa      => Str,
     required => 1,
+);
+
+has recursive => (
+    is      => 'ro',
+    isa     => Bool,
+    default => 0,
 );
 
 1;


### PR DESCRIPTION
This should fetch the entire response for any query that results in pagination. Only tested with the domain_record_list request since that's my use case and worked fine there.

Any code that uses the module without this patch should continue working, since it will not do anything differently unless you create your WebService::DO object with the recursive boolean set.